### PR TITLE
Fix loading guard in plugin/

### DIFF
--- a/plugin/auto-git-diff.vim
+++ b/plugin/auto-git-diff.vim
@@ -1,5 +1,5 @@
-if exists("b:did_auto_git_diff") | finish | endif
-let b:did_auto_git_diff = 1
+if exists("g:did_auto_git_diff") | finish | endif
+let g:did_auto_git_diff = 1
 
 augroup auto_git_diff_command_group
     autocmd!


### PR DESCRIPTION
`b:` はバッファローカル変数ですので，`b:did_auto_git_diff` はカレントバッファを切り替えるとなくなってしまいます．プラグインが2度読まれることを防ぐにはグローバル変数 `g:` を使う必要があります．