### PR TITLE
Add mappings to scroll preview window without moving cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ window. `_1` means scrolling one line (`<C-e>` or `<C-y>`), `_half` means
 scrolling half a page (`<C-d>` or `<C-u>`) and `_page` means scrolling one page
 (`<C-f>` or `<C-b>`).
 
+Following is an example to configure the mappings in your `vimrc`.
+
+```vim
+function! s:setup_auto_git_diff() abort
+    nmap <buffer><C-l> <Plug>(auto_git_diff_scroll_manual_update)
+    nmap <buffer><C-n> <Plug>(auto_git_diff_scroll_down_half)
+    nmap <buffer><C-p> <Plug>(auto_git_diff_scroll_up_half)
+endfunction
+autocmd FileType gitrebase call <SID>setup_auto_git_diff()
+```
+
 ## License
 
     The MIT License (MIT)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ Options passed to `git diff` command. If the variable is not defined,
 Key mapping to update diff window manully. Example:
 `:nmap <Leader>gd <Plug>(auto_git_diff_manual_update)`
 
+ - `<Plug>(auto_git_diff_scroll_down_1)`
+ - `<Plug>(auto_git_diff_scroll_up_1)`
+ - `<Plug>(auto_git_diff_scroll_down_half)`
+ - `<Plug>(auto_git_diff_scroll_up_half)`
+ - `<Plug>(auto_git_diff_scroll_down_page)`
+ - `<Plug>(auto_git_diff_scroll_up_page)`
+
+These key mappings scroll the diff window without moving the cursor into the
+window. `_1` means scrolling one line (`<C-e>` or `<C-y>`), `_half` means
+scrolling half a page (`<C-d>` or `<C-u>`) and `_page` means scrolling one page
+(`<C-f>` or `<C-b>`).
+
 ## License
 
     The MIT License (MIT)

--- a/autoload/auto_git_diff.vim
+++ b/autoload/auto_git_diff.vim
@@ -99,6 +99,16 @@ function! auto_git_diff#auto_update_git_diff() abort
     call auto_git_diff#show_git_diff()
 endfunction
 
+function! auto_git_diff#scroll_in_preview_window(map) abort
+    if s:find_preview_window() == 0
+        return
+    endif
+    wincmd P
+    sandbox let input = eval('"\<'.a:map.'>"')
+    execute "normal!" input
+    wincmd p
+endfunction
+
 let &cpo = s:save_cpo
 unlet s:save_cpo
 

--- a/plugin/auto-git-diff.vim
+++ b/plugin/auto-git-diff.vim
@@ -7,3 +7,10 @@ augroup auto_git_diff_command_group
     autocmd FileType gitrebase setlocal nowarn nowb
 augroup END
 
+nnoremap <silent><Plug>(auto_git_diff_scroll_down_1) :<C-u>call auto_git_diff#scroll_in_preview_window("C-e")<CR>
+nnoremap <silent><Plug>(auto_git_diff_scroll_up_1) :<C-u>call auto_git_diff#scroll_in_preview_window("C-y")<CR>
+nnoremap <silent><Plug>(auto_git_diff_scroll_down_half) :<C-u>call auto_git_diff#scroll_in_preview_window("C-d")<CR>
+nnoremap <silent><Plug>(auto_git_diff_scroll_up_half) :<C-u>call auto_git_diff#scroll_in_preview_window("C-u")<CR>
+nnoremap <silent><Plug>(auto_git_diff_scroll_down_page) :<C-u>call auto_git_diff#scroll_in_preview_window("C-f")<CR>
+nnoremap <silent><Plug>(auto_git_diff_scroll_up_page) :<C-u>call auto_git_diff#scroll_in_preview_window("C-b")<CR>
+


### PR DESCRIPTION
I felt some difficulty on scrolling the preview window.

When the diff is longer than height of preview window, we need to scroll it to check the entire diff. To scroll, cursor needs to go to preview window (and back to rebase buffer). Scroll position of preview window is reset when cursor is moving onto another revision.

So I implemented some mappings to scroll preview window without moving cursor from rebase buffer. Now I'm happy to scroll the window quickly.