### PR TITLE
Use env command to set a environment variable

### DIFF
--- a/autoload/auto_git_diff.vim
+++ b/autoload/auto_git_diff.vim
@@ -69,7 +69,7 @@ function! s:show_git_diff_impl(hash, vertsplit, opts) abort
 endfunction
 
 function! s:get_git_diff(hash, opts) abort
-    let prefix = has("win32") ? "set LANG=C & " : "LANG=C "
+    let prefix = has("win32") ? "set LANG=C & " : "env LANG=C "
 
     let diff_command = "git diff ".a:opts." ".a:hash."~1 ".a:hash
     silent let out = system(prefix.diff_command)


### PR DESCRIPTION
Some shells like tcsh & fish need env command to execute a command with a specific environment variable.

The following error is shown when using fish.

```
fish: Unsupported use of '='. To run 'git' with a modified environment, please use 'env LANG=C git…'
LANG=C git diff --stat -p --submodule -C -C f65f8f4~1 f65f8f4
^
```
